### PR TITLE
chore: remove overleaf resume sync docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,10 +12,11 @@ Stack: React Router v6, Bootstrap 5, react-bootstrap, GitHub Actions, gh-pages b
 
 Study the existing codebase before suggesting anything. Specifically:
 
-- How `src/components/Projects/Projects.jsx` and `ProjectCards.jsx` are structured
-- How `src/App.jsx` defines routes
-- How `src/components/Navbar.jsx` adds nav items
-- How `.github/workflows/deploy.yml` and `build-resume.yml` work
+-- How `src/components/Projects/Projects.jsx` and `ProjectCards.jsx` are structured
+-- How `src/App.jsx` defines routes
+-- How `src/components/Navbar.jsx` adds nav items
+-- How `.github/workflows/deploy.yml` works
+
 - The dark theme CSS variables in `src/style.css` and `src/App.css`
 
 Every suggestion must be consistent with those patterns. Do not introduce new patterns
@@ -39,10 +40,7 @@ functions. The repo is the database.
    Each tab has a form to add new entries (name, description, image upload, URLs, etc).
    Certifications also accept a PDF upload.
 
-3. **GitHub Actions CMS workflow** — a new `cms-update.yml` that listens on
-   `repository_dispatch` events fired by the Admin UI. It validates the admin JWT,
-   commits the new JSON + uploaded assets directly to the repo, then triggers `deploy.yml`
-   so the site rebuilds automatically. No manual steps after form submission.
+3. **CMS Processing** — Uploads are handled by the Cloudflare Worker in production or by the GitHub API in development. The worker/API validates the admin JWT, writes assets and JSON to the repository, and ensures `deploy.yml` runs to rebuild the site. No manual steps after form submission.
 
 ---
 
@@ -115,15 +113,13 @@ const AdminApp = React.lazy(() => import("./components/Admin/AdminApp"));
 All admin components live in `src/components/Admin/`. They are never imported by any
 non-admin component. The public bundle has zero admin code.
 
-### GitHub Actions integration
+### CMS Processing (Worker / API)
 
-- Admin form submission → `dispatchCmsEvent()` → GitHub API `repository_dispatch`
+- Admin form submission → `dispatchCmsEvent()` → Cloudflare Worker (production) or GitHub API (development)
 - Event types: `add-project`, `update-project`, `delete-project`,
   `add-cert`, `update-cert`, `delete-cert`
-- `cms-update.yml` receives the event, validates JWT, reads JSON, applies change with
-  `jq` or Python, commits, pushes, then runs `gh workflow run deploy.yml`.
-- `deploy.yml` is untouched. It still builds and pushes to gh-pages as before.
-- Never string-concat JSON in shell. Use `jq` or Python for all JSON manipulation.
+- Processing: Worker/API validates JWT, decodes files, updates JSON, and pushes changes; `deploy.yml` handles deployment.
+- Never string-concat JSON in shell. Use `jq` or Python for any server-side JSON manipulation.
 - Sanitize all payload fields before using them in file paths (no path traversal).
 
 ### Image handling in the browser
@@ -155,7 +151,7 @@ public/data/
   certs.json               ← start as []
 
 .github/workflows/
-  cms-update.yml           ← new workflow
+  deploy.yml               ← Deploy workflow
 
 .env.local (never commit)
   VITE_ADMIN_PASSWORD=
@@ -163,7 +159,6 @@ public/data/
 
 GitHub Secrets
   ADMIN_SECRET             ← same value as VITE_ADMIN_PASSWORD
-  OVERLEAF_PROJECT_ID      ← existing, unchanged
 ```
 
 ---
@@ -191,7 +186,7 @@ GitHub Secrets
 - Netlify or Vercel serverless functions
 - localStorage for auth tokens
 - New npm packages for JWT (use Web Crypto API)
-- Modifying `deploy.yml` or `build-resume.yml`
+  -- Modifying `deploy.yml`
 - Hardcoding secrets or PATs in source files
 - `document.cookie` for session management
 

--- a/CMS_SETUP.md
+++ b/CMS_SETUP.md
@@ -13,7 +13,7 @@ Your portfolio now has a complete **Certification Management System** with autom
 ## How It Works (3-Step Process)
 
 1. **You submit** → Go to `your-site.com/admin`, login, fill form, upload image/PDF
-2. **Workflow processes** → `cms-update.yml` validates JWT, saves files, updates JSON
+2. **Processing** → Uploads are handled by the Cloudflare Worker in production or by the GitHub API in development.
 3. **Site rebuilds** → `deploy.yml` triggers automatically, live in ~60 seconds
 
 ## Setup (5 Minutes)
@@ -75,7 +75,7 @@ src/components/Admin/
 └── githubApi.js          ← GitHub dispatch integration
 
 .github/workflows/
-└── cms-update.yml        ← Handles uploads & updates
+└── deploy.yml            ← Deploys site to GitHub Pages
 
 public/data/
 ├── certs.json           ← Certification database
@@ -129,15 +129,13 @@ Admin Form Submit
     ↓
 Issue JWT Token
     ↓
-Send repository_dispatch
-    ↓
-GitHub Actions: cms-update.yml
+Send to Cloudflare Worker (production) or GitHub API (development)
     ↓
 [Validate JWT] → [Decode Files] → [Create Slug] → [Save Assets]
     ↓
 Update certs.json
     ↓
-Git commit & push
+Git commit & push (performed by worker/API)
     ↓
 Trigger deploy.yml
     ↓

--- a/README.md
+++ b/README.md
@@ -63,14 +63,13 @@ This portfolio now includes a **complete Content Management System** for zero-co
 - Issue date tracking
 - Automatic slug generation
 
-#### 4. GitHub Actions CMS Workflow (`cms-update.yml`)
+#### 4. CMS Processing (Cloudflare Worker / GitHub API)
 
-- Processes CMS events automatically
+- Processing is handled by the Cloudflare Worker in production or the GitHub API in development
 - Validates JWT tokens before any changes
 - Handles file encoding/decoding
-- Updates JSON database
-- Triggers automatic deployment
-- Changes live in ~60 seconds
+- Updates JSON database (`public/data/*.json`)
+- Triggers deployment (via `deploy.yml`) so changes go live in ~60 seconds
 
 #### 5. Navbar Update
 
@@ -160,7 +159,7 @@ npm run dev
 - **GitHub Integration** - Activity calendar
 - **Tech Stack Showcase** - Visual skills display
 - **Dark Theme** - Professional dark mode
-- **Automated Resume Sync** - Syncs from Overleaf via GitHub Actions
+- **Resume PDF** - The resume PDF is stored locally in `public/resume/Chirag_Dhunna.pdf`
 
 ### CMS Features (New)
 
@@ -213,11 +212,9 @@ npm run dev
 ```
 chiragdhunna.github.io/
 ├── .github/workflows/
-│   ├── build-resume.yml           # Resume sync from Overleaf
-│   ├── deploy.yml                 # Deploy to GitHub Pages
-│   └── cms-update.yml             # 🆕 CMS event processing
+│   └── deploy.yml                 # Deploy to GitHub Pages
 ├── public/
-│   ├── CHIRAG_DHUNNA.pdf         # Auto-synced resume
+│   ├── resume/Chirag_Dhunna.pdf  # Resume PDF (stored in public/resume/)
 │   ├── data/                      # 🆕 JSON databases
 │   │   ├── certs.json            # Certifications
 │   │   └── projects.json         # Projects
@@ -356,20 +353,20 @@ npm run deploy
 ### System Overview
 
 ```
-Browser Admin Panel          GitHub Repository       GitHub Actions
-    ↓                              ↓                        ↓
-1. User fills form           .env.local (dev)    Workflow: cms-update.yml
+Browser Admin Panel          GitHub Repository       Worker / GitHub API
+   ↓                              ↓                        ↓
+1. User fills form           .env.local (dev)    Worker (prod) or API (dev)
 2. Issues JWT token          .env.example
-3. Converts to base64        certs.json          Step 1: Check JWT valid
-4. Sends to GitHub           assets/certs/       Step 2: Decode files
+3. Converts to base64        certs.json          Step 1: Validate token
+4. Sends to worker/API       assets/certs/       Step 2: Decode files
 5. Waits for update          ...                 Step 3: Create slug
-                                                 Step 4: Save assets
-                                                 Step 5: Update JSON
-                                                 Step 6: Git commit+push
-                                                 Step 7: Trigger deploy
-                                                        ↓
-                                                 Site rebuilds & goes live
-                                                 ✅ Changes visible (~60s)
+                                     Step 4: Save assets
+                                     Step 5: Update JSON
+                                     Step 6: Git commit & push
+                                     Step 7: Trigger deploy
+                                          ↓
+                                     Site rebuilds & goes live
+                                     ✅ Changes visible (~60s)
 ```
 
 ### Data Flow: Detailed
@@ -377,20 +374,16 @@ Browser Admin Panel          GitHub Repository       GitHub Actions
 1. **Admin Submission** - User fills form at `/admin`
 2. **Client Processing** - Image resized, files encoded to base64
 3. **Token Generation** - JWT created using HMAC-SHA256
-4. **GitHub API Call** - `repository_dispatch` event sent
-5. **Workflow Trigger** - `cms-update.yml` receives event
-6. **JWT Validation** - Python script validates signature
-7. **File Decoding** - Base64 decoded back to binary
-8. **File Storage** - Images/PDFs saved to `public/assets/certs/`
-9. **JSON Update** - New entry appended to `certs.json`
-10. **Git Operations** - Changes committed and pushed
-11. **Deploy Trigger** - `deploy.yml` workflow starts
-12. **Site Rebuild** - React app built with new data
-13. **Live Update** - Changes visible on site
+4. **Upload** - In production the Cloudflare Worker receives the payload; in development the client may call GitHub's `repository_dispatch`.
+5. **Processing** - Worker/API validates JWT, decodes files, and writes assets and JSON to the repo
+6. **Git Operations** - Changes are committed and pushed to the repository
+7. **Deploy Trigger** - `deploy.yml` workflow starts on push
+8. **Site Rebuild** - React app built with new data
+9. **Live Update** - Changes visible on site
 
-### GitHub Actions Workflow (`cms-update.yml`)
+### CMS Processing (Worker / API)
 
-**Events Handled:**
+**Events Handled (examples):**
 
 - `add-cert` - Add certification
 - `update-cert` - Update certification (extensible)
@@ -401,22 +394,19 @@ Browser Admin Panel          GitHub Repository       GitHub Actions
 
 **Security Checks:**
 
-1. ✅ Validates JWT signature with `ADMIN_SECRET`
+1. ✅ Validates JWT signature with `ADMIN_SECRET` (worker/API)
 2. ✅ Checks file MIME types (JPG/PNG for images, PDF for docs)
 3. ✅ Enforces file size limits (5MB images, 10MB PDFs)
 4. ✅ Sanitizes filenames (removes special characters)
 5. ✅ Never processes if validation fails
 
-**Operations:**
+**Operations (performed by worker/API):**
 
-1. Checkout repository
-2. Setup Python 3.11
-3. Validate JWT signature
-4. Decode base64 files
-5. Update JSON database
-6. Create meaningful commit
-7. Push to main branch
-8. Trigger deploy workflow
+1. Validate JWT
+2. Decode base64 files
+3. Save assets to `public/assets/` and update `public/data/*.json`
+4. Commit changes and push to the repository
+5. Trigger `deploy.yml` (push-based) to rebuild the site
 
 ---
 
@@ -712,12 +702,8 @@ Edit [src/components/Projects/Projects.jsx](src/components/Projects/Projects.jsx
 
 ### Update Resume
 
-Your resume auto-syncs from Overleaf:
-
-1. Edit in [Overleaf](https://www.overleaf.com)
-2. GitHub Actions downloads daily
-3. Manual trigger: Actions tab → "Sync Resume" → Run workflow
-4. No manual uploads needed
+The resume PDF is stored locally in the repository at `public/resume/Chirag_Dhunna.pdf`.
+To update the resume, replace that file and push changes; the site will rebuild via the normal deploy workflow.
 
 ### Style Customization
 
@@ -743,7 +729,7 @@ Modify CSS variables to customize globally.
 1. Enhance `ProjectForm.jsx`
 2. Add to AdminDashboard tabs
 3. Handle events: `add-project`, `update-project`, `delete-project`
-4. Update `cms-update.yml` workflow
+4. Update server-side processing (Cloudflare Worker or GitHub workflow)
 
 **For Other Content:**
 
@@ -796,9 +782,9 @@ Modify CSS variables to customize globally.
 **Checklist:**
 
 1. Wait 60+ seconds
-2. Check GitHub Actions → latest run
-3. Verify `cms-update.yml` succeeded
-4. Verify `deploy.yml` also ran
+2. Check Cloudflare Worker logs (production) or GitHub Actions → latest run (development)
+3. Verify the worker/API processing completed successfully
+4. Verify `deploy.yml` also ran (or was triggered by the processing)
 5. Hard refresh: `Ctrl+Shift+R`
 6. Check browser console for errors
 
@@ -852,7 +838,7 @@ Modify CSS variables to customize globally.
 **Solution:**
 
 1. Check GitHub Actions → `deploy.yml`
-2. Verify it triggered after `cms-update.yml`
+2. Verify it was triggered by the worker/API push or other commit
 3. If not: check Actions enabled in Settings
 4. Verify `deploy.yml` has `on: push` trigger
 
@@ -942,21 +928,10 @@ npm run dev -- --port 3001
 
 ---
 
-## 🔄 Resume Synchronization
+## 🔄 Resume
 
-Your resume auto-syncs from Overleaf:
-
-1. **Edit in Overleaf** - Make LaTeX changes
-2. **Auto Sync** - GitHub Actions downloads daily
-3. **Manual Trigger** - Actions → "Sync Resume" → Run workflow
-4. **No Manual Upload** - Fully automated
-
-**Setup (if using):**
-
-1. Share Overleaf project (link sharing enabled)
-2. Copy project ID from share URL
-3. Add GitHub Secret: `OVERLEAF_PROJECT_ID`
-4. Workflow runs daily at midnight UTC
+The resume PDF is stored locally in the repository at `public/resume/Chirag_Dhunna.pdf`.
+To update the resume, replace that file and push changes; the site will rebuild via the normal deploy workflow.
 
 ---
 

--- a/src/components/Admin/README.md
+++ b/src/components/Admin/README.md
@@ -15,7 +15,7 @@ This is a GitHub-based CMS for managing certifications and projects without touc
   - `public/assets/certs/<slug>.jpg` - Certification images
   - `public/assets/certs/<slug>.pdf` - Certificate PDFs
   - `public/assets/projects/<slug>.jpg` - Project images
-- **Workflow**: GitHub Actions (`cms-update.yml`) processes dispatch events
+- **Processing**: Cloudflare Worker (production) or GitHub API (development) processes uploads.
 
 ## Setup Instructions
 
@@ -46,7 +46,6 @@ VITE_GITHUB_PAT=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 In your GitHub repository Settings → Secrets and variables → Actions:
 
 1. Create secret `ADMIN_SECRET` with the same value as `VITE_ADMIN_PASSWORD`
-2. (Optional) Create secret `OVERLEAF_PROJECT_ID` if using resume sync
 
 ### 3. Test the Admin Panel
 
@@ -73,16 +72,17 @@ In your GitHub repository Settings → Secrets and variables → Actions:
 
 1. Admin UI encodes files to base64
 2. Issues JWT token signed with admin password
-3. Sends `repository_dispatch` event to GitHub Actions with JWT
-4. `cms-update.yml` workflow:
-   - Validates JWT with admin secret
-   - Decodes files from base64
-   - Creates slug from name (kebab-case)
-   - Saves image to `public/assets/certs/<slug>.jpg`
-   - Saves PDF to `public/assets/certs/<slug>.pdf`
-   - Appends entry to `public/data/certs.json`
-   - Commits changes with message "chore: update certifications from CMS"
-   - Triggers `deploy.yml` to rebuild the site
+3. Sends the upload to the Cloudflare Worker (production) or uses `repository_dispatch` to call the GitHub API in development.
+4. Worker/API processing:
+
+- Validates JWT with admin secret
+- Decodes files from base64
+- Creates slug from name (kebab-case)
+- Saves image to `public/assets/certs/<slug>.jpg`
+- Saves PDF to `public/assets/certs/<slug>.pdf`
+- Appends entry to `public/data/certs.json`
+- Commits changes and pushes to the repo
+- Triggers `deploy.yml` to rebuild the site
 
 ## Data Schema
 
@@ -147,7 +147,7 @@ Ensure `ADMIN_SECRET` in GitHub Secrets exactly matches `VITE_ADMIN_PASSWORD`
 ### Changes not appearing
 
 1. Check GitHub Actions tab in repo settings
-2. Verify `cms-update.yml` workflow ran successfully
+2. Verify the worker/API processing completed successfully (check worker logs or Actions)
 3. Check the `deploy.yml` workflow also completed
 4. Hard-refresh browser cache (Ctrl+Shift+R)
 
@@ -175,7 +175,7 @@ src/components/Admin/
 └── githubApi.js              # GitHub dispatch integration
 
 .github/workflows/
-└── cms-update.yml            # GitHub Actions workflow
+└── (processing handled by Cloudflare Worker in production or GitHub API in development)
 
 .env.example                  # Environment variable template
 ```

--- a/src/components/Resume/ResumeNew.jsx
+++ b/src/components/Resume/ResumeNew.jsx
@@ -10,11 +10,7 @@ import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 const pdfjsVersion = pdfjs.version;
 pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjsVersion}/build/pdf.worker.min.js`;
 
-// OVERLEAF SETUP:
-// Option 1: Use local PDF (synced via GitHub Actions)
-// Option 2: Use direct Overleaf link (uncomment and add your project ID)
-// const OVERLEAF_PROJECT_ID = "YOUR_PROJECT_ID_HERE";
-// const OVERLEAF_PDF = `https://www.overleaf.com/download/project/${OVERLEAF_PROJECT_ID}/build/output.pdf?compileGroup=standard`;
+// Resume PDF (stored in the repo's `public/` folder)
 
 function ResumeNew() {
   const [width, setWidth] = useState(1200);
@@ -23,8 +19,7 @@ function ResumeNew() {
   const [pdfData, setPdfData] = useState(null);
   const [renderFallback, setRenderFallback] = useState(false);
 
-  // Use local PDF (synced from Overleaf via GitHub Actions)
-  // Or replace with OVERLEAF_PDF to load directly from Overleaf
+  // Use the local PDF stored in `public/resume/`.
   const pdf = "/resume/Chirag_Dhunna.pdf";
 
   useEffect(() => {
@@ -106,9 +101,6 @@ function ResumeNew() {
       alert("Failed to download PDF. Please try again.");
     }
   };
-
-  // Use local PDF (synced from Overleaf via GitHub Actions)
-  // Or replace with OVERLEAF_PDF to load directly from Overleaf
 
   return (
     <div>


### PR DESCRIPTION
This PR removes the stale Overleaf-based resume sync references from the repo and updates the portfolio docs to reflect the current setup.

What changed:

Removed Overleaf sync wording from [README.md](vscode-file://vscode-app/c:/Users/chira/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated CMS docs to describe the current Cloudflare Worker / GitHub API processing flow
Removed cms-update.yml references from repo instructions and admin docs
Kept the resume pointed at the local file in [Chirag_Dhunna.pdf](vscode-file://vscode-app/c:/Users/chira/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Cleaned up the Resume component comments so there are no remaining Overleaf referencesThis PR removes the stale Overleaf-based resume sync references from the repo and updates the portfolio docs to reflect the current setup.

What changed:

Removed Overleaf sync wording from [README.md](vscode-file://vscode-app/c:/Users/chira/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated CMS docs to describe the current Cloudflare Worker / GitHub API processing flow
Removed cms-update.yml references from repo instructions and admin docs
Kept the resume pointed at the local file in [Chirag_Dhunna.pdf](vscode-file://vscode-app/c:/Users/chira/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Cleaned up the Resume component comments so there are no remaining Overleaf references