### PR TITLE
feat(admin): refine project form and dashboard UI

### DIFF
--- a/src/components/Admin/AdminDashboard.css
+++ b/src/components/Admin/AdminDashboard.css
@@ -512,6 +512,7 @@
 .proj-info {
   min-width: 0;
   flex: 1;
+  text-align: left; /* ← add this */
 }
 
 .proj-name {
@@ -521,6 +522,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: left; /* ← add this */
 }
 
 .proj-cats {

--- a/src/components/Admin/ProjectForm.css
+++ b/src/components/Admin/ProjectForm.css
@@ -263,3 +263,44 @@
 .pf-btn--save:hover:not(:disabled) {
   background: rgba(91, 156, 246, 0.18);
 }
+
+.pf-cat--custom {
+  background: rgba(91, 156, 246, 0.1);
+  border-color: #5b9cf6;
+  color: #5b9cf6;
+}
+
+.pf-cat-add {
+  display: flex;
+  align-items: center;
+}
+
+.pf-cat-input {
+  background: #1d1f21;
+  border: 1px dashed #35383c;
+  border-radius: 4px;
+  color: #e8eaed;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  padding: 5px 10px;
+  outline: none;
+  width: 120px;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.pf-cat-input:focus {
+  border-color: #c8891a;
+  border-style: solid;
+  box-shadow: 0 0 0 3px rgba(240, 165, 0, 0.08);
+}
+
+.pf-cat-input::placeholder {
+  color: #5f6368;
+}
+
+.pf-cat-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/Admin/ProjectForm.jsx
+++ b/src/components/Admin/ProjectForm.jsx
@@ -27,6 +27,7 @@ function ProjectForm({ editProject, onSuccess, onCancelEdit }) {
   const [loading, setLoading] = useState(false);
   const [msgOk, setMsgOk] = useState("");
   const [msgErr, setMsgErr] = useState("");
+  const [customCatInput, setCustomCatInput] = useState("");
 
   useEffect(() => {
     if (editProject) {
@@ -51,6 +52,7 @@ function ProjectForm({ editProject, onSuccess, onCancelEdit }) {
     setImageFile(null);
     setMsgOk("");
     setMsgErr("");
+    setCustomCatInput("");
   }, [editProject]);
 
   const handleInput = (e) => {
@@ -65,6 +67,14 @@ function ProjectForm({ editProject, onSuccess, onCancelEdit }) {
         ? p.categories.filter((c) => c !== cat)
         : [...p.categories, cat],
     }));
+  };
+
+  const addCustomCat = () => {
+    const val = customCatInput.trim();
+    if (val && !formData.categories.includes(val)) {
+      setFormData((p) => ({ ...p, categories: [...p.categories, val] }));
+    }
+    setCustomCatInput("");
   };
 
   const handleImage = (e) => {
@@ -207,6 +217,7 @@ function ProjectForm({ editProject, onSuccess, onCancelEdit }) {
               categories <span className="pf-req">*</span>
             </label>
             <div className="pf-cats">
+              {/* Predefined category pills */}
               {CATEGORY_OPTIONS.map((cat) => (
                 <button
                   key={cat}
@@ -218,6 +229,40 @@ function ProjectForm({ editProject, onSuccess, onCancelEdit }) {
                   {cat}
                 </button>
               ))}
+
+              {/* Custom category pills */}
+              {formData.categories
+                .filter((c) => !CATEGORY_OPTIONS.includes(c))
+                .map((cat) => (
+                  <button
+                    key={cat}
+                    type="button"
+                    className="pf-cat pf-cat--on pf-cat--custom"
+                    onClick={() => toggleCat(cat)}
+                    disabled={loading}
+                    title="click to remove"
+                  >
+                    {cat} ✕
+                  </button>
+                ))}
+
+              {/* Custom category input */}
+              <div className="pf-cat-add">
+                <input
+                  className="pf-cat-input"
+                  type="text"
+                  placeholder="+ custom…"
+                  value={customCatInput}
+                  onChange={(e) => setCustomCatInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      addCustomCat();
+                    }
+                  }}
+                  disabled={loading}
+                />
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
This pull request enhances the project admin interface by improving the category selection experience in the `ProjectForm` component and making minor visual adjustments to the dashboard. The main focus is the addition of a user-friendly way to add and display custom categories, along with related styling updates.

**ProjectForm custom category support:**

* Added state and logic to allow users to input and add custom categories directly in the `ProjectForm`. Custom categories are displayed as removable pills alongside predefined options. [[1]](diffhunk://#diff-e124a12ec5e0d9e561ddef548ea0884364b77c2d4cfb14f36ced95f445c96338R30) [[2]](diffhunk://#diff-e124a12ec5e0d9e561ddef548ea0884364b77c2d4cfb14f36ced95f445c96338R72-R79) [[3]](diffhunk://#diff-e124a12ec5e0d9e561ddef548ea0884364b77c2d4cfb14f36ced95f445c96338R220) [[4]](diffhunk://#diff-e124a12ec5e0d9e561ddef548ea0884364b77c2d4cfb14f36ced95f445c96338R232-R265)
* Reset the custom category input field when editing a new or existing project to ensure a clean form state.

**Styling improvements:**

* Introduced new CSS classes in `ProjectForm.css` for custom category pills, the input field, and layout, ensuring a consistent and accessible appearance for the new feature.
* Aligned text to the left in project info and name columns on the admin dashboard for better readability. [[1]](diffhunk://#diff-2db728d29214020cb62250cf4ab795e00172a8e061da3f398f145b3085ec3634R515) [[2]](diffhunk://#diff-2db728d29214020cb62250cf4ab795e00172a8e061da3f398f145b3085ec3634R525)